### PR TITLE
2 when 2000000000 is passed as the number of threads the program crashes

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -7,3 +7,5 @@ FUN-DISPLAY-RESULTS - The system shall display the results of Monty Hall simulat
 FUN-DISPLAY-ITERATIONS - The system shall display the number of iterations executed by each thread, where there are as many threads as specified in the arguments.  The sum of the number of iterations shall be equal to the number of times specified in the arguments.  Each thread shall execute an equal share of the number of times, or be off by at most 1 if number of times is not a multiple of the number of threads.
 
 FUN-SMALL-NUM - If the "number of times" argument is less than 100, the system shall issue a warning and ask the user if they wish to continue.
+
+FUN-MAXINT-NUM - If the "number of times" is equal to 2147483648, the system displays "Integer overflow detected" and the program shuts down.

--- a/requirements.md
+++ b/requirements.md
@@ -8,4 +8,6 @@ FUN-DISPLAY-ITERATIONS - The system shall display the number of iterations execu
 
 FUN-SMALL-NUM - If the "number of times" argument is less than 100, the system shall issue a warning and ask the user if they wish to continue.
 
-FUN-MAXINT-NUM - If the "number of times" is equal to 2147483648, the system displays "Integer overflow detected" and the program shuts down.
+FUN-MAXINT-NUM - If the "number of times" argument is equal to 2147483648, the system displays "Integer overflow detected" and the program shuts down.
+
+FUN-LARGE-THREADS- If the "number of threads" argument is greater than 2000000000 (not the exact boundary), the system displays "Exceed maximum threads" and the program shuts down.


### PR DESCRIPTION
Fix the LARGE-THREADS bug 